### PR TITLE
Update VEML6040.ino, ITime larger than 160ms needs uint16_t

### DIFF
--- a/VEML6040.ino
+++ b/VEML6040.ino
@@ -62,7 +62,7 @@ enum IT {
 
 // Specify VEML6070 Integration time
 uint8_t IT = IT_160;
-uint8_t ITime = 160;  // milliseconds
+uint16_t ITime = 160;  // milliseconds
 uint16_t RGBWData[4] = {0, 0, 0, 0};
 float GSensitivity = 0.25168/((float) (1 << IT)); // ambient light sensitivity increases with integration time
 


### PR DESCRIPTION
The integration time variable, ITime is defined as uint8 so when using integration times higher than 255 it overflows to an unintended value. The maximun integration time is 1280ms so uint16 should suffice.